### PR TITLE
<select> for bpm

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
         <div class="pure-u-1-1">
           <form class="pure-form" id="metronome-form">
             <label for="metronome">Metronome tempo</label>
-            <input type="number" value="120" min="40" max="208" id="metronome" disabled />
+            <select name="metronome" id="metronome" class="full-width" disabled></select>
             <label for="metronome-signature">Metronome time signature</label>
             <select name="metronome-signature" id="metronome-signature" class="full-width" disabled>
               <option value="1/1">1/1</option>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -56,7 +56,15 @@ function update_ui(ui, data) {
     ui.data_table.appendChild(tr);
   }
 
-  ui.metronome_bpm.value = data.metronome.bpm;
+  // Find the closest bpm value from the list of options
+  for (const bpm_opt of ui.metronome_bpm.options) {
+    if (parseInt(bpm_opt.value) <= parseInt(data.metronome.bpm)) {
+      ui.metronome_bpm.value = bpm_opt.value;
+    } else {
+      break;
+    }
+  }
+
   ui.metronome_signature.value = data.metronome.timesig;
   ui.metronome_volume.value = data.metronome.volume_db;
   ui.metronome_accent.checked = data.metronome.accentuate;
@@ -122,6 +130,13 @@ async function main() {
       handle_error(ui, error);
     });
   })
+
+  // Reproduces the list from the PianoTeq tempo menu
+  for (let i = 40; i < 60; i += 4) ui.metronome_bpm.add(new Option(i + ' bpm', i));
+  for (let i = 60; i < 72; i += 3) ui.metronome_bpm.add(new Option(i + ' bpm', i));
+  for (let i = 72; i < 120; i += 4) ui.metronome_bpm.add(new Option(i + ' bpm', i));
+  for (let i = 120; i < 144; i += 6) ui.metronome_bpm.add(new Option(i + ' bpm', i));
+  for (let i = 144; i <= 208; i += 8) ui.metronome_bpm.add(new Option(i + ' bpm', i));
 
   const metronome_update = async function() {
     set_ui_disabled(ui, true);

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -57,8 +57,9 @@ function update_ui(ui, data) {
   }
 
   // Find the closest bpm value from the list of options
+  const bpm = Number(data.metronome.bpm);
   for (const bpm_opt of ui.metronome_bpm.options) {
-    if (parseInt(bpm_opt.value) <= parseInt(data.metronome.bpm)) {
+    if (Number(bpm_opt.value) <= bpm) {
       ui.metronome_bpm.value = bpm_opt.value;
     } else {
       break;
@@ -137,12 +138,17 @@ async function main() {
   for (let i = 72; i < 120; i += 4) ui.metronome_bpm.add(new Option(i + ' bpm', i));
   for (let i = 120; i < 144; i += 6) ui.metronome_bpm.add(new Option(i + ' bpm', i));
   for (let i = 144; i <= 208; i += 8) ui.metronome_bpm.add(new Option(i + ' bpm', i));
+  ui.metronome_bpm.add(new Option('Other value...', 999));
 
   const metronome_update = async function() {
     set_ui_disabled(ui, true);
-    const bpm = parseInt(ui.metronome_bpm.value);
+    const bpm = Number(
+      ui.metronome_bpm.value == '999'
+        ? window.prompt('Enter the new BPM value', '')
+        : ui.metronome_bpm.value
+    );
     const signature = ui.metronome_signature.value;
-    const volume = parseInt(ui.metronome_volume.value);
+    const volume = Number(ui.metronome_volume.value);
     const accent = ui.metronome_accent.checked;
     await pianoteq.config_metronome(bpm, signature, volume, accent).then(async(data) => {
       await refresh_and_reenable_ui(ui);


### PR DESCRIPTION
Fixes the _"TCP: request_sock_TCP: Possible SYN flooding on port 8000.  Sending cookies.  Check SNMP counters."_ warnings in `dmesg`. While manually editing the metronome bpm on a phone, too many change events are dispatched. Not good.