### PR TITLE
Fixed manifest.webmanifest corruption

### DIFF
--- a/server.py
+++ b/server.py
@@ -30,15 +30,6 @@ class StaticAndForwardHandler(SimpleHTTPRequestHandler):
       self.wfile.write(res.read())
       return
 
-    # Kind of a hack, but whatever
-    if self.path == "/manifest.webmanifest":
-      self.send_response(200)
-      self.send_header("Content-type", "application/manifest+json")
-      self.end_headers()
-
-      with open("manifest.webmanifest", "rb") as f:
-        self.wfile.write(f.read())
-
     super().do_GET()
 
   def do_POST(self):


### PR DESCRIPTION
Since the file already exists, the removed lines make HTTPServer duplicate the content, becoming:

```
<HEADERS>
<CONTENT>
<HEADERS>
<CONTENT>
```

Which results in corrupted JSON. Besides, HTTPServer does "know" the correct `Content-Type` for `.webmanifest` extension.